### PR TITLE
added ability to join existing list

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,11 +8,22 @@ import Home from './views/Home/Home.jsx';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token'));
+  const [hasToken, setHasToken] = useState(token !== null);
 
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Home token={token} setToken={setToken} />} />
+        <Route
+          path="/"
+          element={
+            <Home
+              token={token}
+              setToken={setToken}
+              hasToken={hasToken}
+              setHasToken={setHasToken}
+            />
+          }
+        />
         <Route path="/list" element={<List token={token} />} />
         <Route path="/additem" element={<AddItem token={token} />} />
       </Routes>

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
-const JoinList = ({ token, handleClick }) => {
+const JoinList = ({ token, handleClick, handleChange }) => {
   return (
     <div>
       <h3>Welcome to your Smart Shopping list!</h3>
@@ -12,6 +12,7 @@ const JoinList = ({ token, handleClick }) => {
           type="text"
           placeholder="three word token"
           defaultValue={token}
+          onChange={handleChange}
         />
       </div>
       {/* <NavLink to="/list"> */}

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -17,7 +17,6 @@ const JoinList = ({ token, handleClick, handleChange, formError }) => {
           onChange={handleChange}
         />
       </div>
-      ``
       <button onClick={handleClick}>Join an existing list</button>
     </div>
   );

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
 
-const JoinList = ({ token, handleClick, handleChange }) => {
+const JoinList = ({ token, handleClick, handleChange, formError }) => {
   return (
     <div>
-      {/* <h3>Welcome to your Smart Shopping list!</h3> */}
-      <p> Join an existing shopping list by entering a three word token </p>
+      {formError ? (
+        <p>{formError}</p>
+      ) : (
+        <p> Join an existing shopping list by entering a three word token </p>
+      )}
+
       <div>
         <label htmlFor="share-token">Share Token:</label>
         <input
@@ -15,9 +18,7 @@ const JoinList = ({ token, handleClick, handleChange }) => {
           onChange={handleChange}
         />
       </div>
-      <Link to="/list">
-        <button onClick={handleClick}>Join an existing list</button>
-      </Link>
+      <button onClick={handleClick}>Join an existing list</button>
     </div>
   );
 };

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
-const JoinList = (props) => {
+const JoinList = ({ token, handleClick }) => {
   return (
     <div>
       <h3>Welcome to your Smart Shopping list!</h3>
       <p> Join an existing shopping list by entering a three word token </p>
       <div>
         <label htmlFor="share-token">Share Token:</label>
-        <input 
-            type="text" 
-            placeholder="three word token" 
-            defaultValue={props.token} />
+        <input
+          type="text"
+          placeholder="three word token"
+          defaultValue={token}
+        />
       </div>
-      <NavLink to="/list">
-        <button>Join an existing list</button>
-      </NavLink>
+      {/* <NavLink to="/list"> */}
+      <button onClick={handleClick}>Join an existing list</button>
+      {/* </NavLink> */}
     </div>
   );
 };

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 const JoinList = ({ token, handleClick, handleChange }) => {
   return (
     <div>
-      {/* <h3>Welcome to your Smart Shopping list!</h3> */}
       <p> Join an existing shopping list by entering a three word token </p>
       <div>
         <label htmlFor="share-token">Share Token:</label>

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -4,7 +4,7 @@ import { NavLink } from 'react-router-dom';
 const JoinList = ({ token, handleClick }) => {
   return (
     <div>
-      <h3>Welcome to your Smart Shopping list!</h3>
+      {/* <h3>Welcome to your Smart Shopping list!</h3> */}
       <p> Join an existing shopping list by entering a three word token </p>
       <div>
         <label htmlFor="share-token">Share Token:</label>
@@ -14,9 +14,9 @@ const JoinList = ({ token, handleClick }) => {
           defaultValue={token}
         />
       </div>
-      {/* <NavLink to="/list"> */}
-      <button onClick={handleClick}>Join an existing list</button>
-      {/* </NavLink> */}
+      <NavLink to="/list">
+        <button onClick={handleClick}>Join an existing list</button>
+      </NavLink>
     </div>
   );
 };

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const JoinList = ({ token, handleClick, handleChange }) => {
   return (
@@ -15,9 +15,9 @@ const JoinList = ({ token, handleClick, handleChange }) => {
           onChange={handleChange}
         />
       </div>
-      <NavLink to="/list">
+      <Link to="/list">
         <button onClick={handleClick}>Join an existing list</button>
-      </NavLink>
+      </Link>
     </div>
   );
 };

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -3,13 +3,21 @@ import { getToken } from '@the-collab-lab/shopping-list-utils';
 import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
 import { getFirestore } from 'firebase/firestore';
+import { Navigate } from 'react-router-dom';
 
-const Home = ({ token, setToken }) => {
-  const [hasToken, setHasToken] = useState(token !== null);
+const Home = ({ token, setToken, hasToken, setHasToken }) => {
+  const [joinList, setJoinList] = useState();
+
+  const handleChange = (e) => {
+    setJoinList(e.target.value);
+  };
 
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
+    if (hasToken) {
+      <Navigate to="/list" />;
+    }
   }, []);
 
   const handleCreateToken = () => {
@@ -17,11 +25,11 @@ const Home = ({ token, setToken }) => {
     localStorage.setItem('token', newToken);
     setToken(newToken);
   };
-
   const handleJoinList = () => {
-    // const token = localStorage.getItem('token')
-    console.log('this is a fun console log');
-    getFirestore.listCollections().then((collections) => {
+    const db = getFirestore();
+    console.log(joinList);
+    console.log('this is a fun console log', db);
+    db.listCollections().then((collections) => {
       for (let collection of collections) {
         console.log(`Found collection with id: ${collection.id}`);
       }
@@ -30,11 +38,12 @@ const Home = ({ token, setToken }) => {
 
   return (
     <div>
-      {!hasToken ? (
-        <CreateList newToken={handleCreateToken} />
-      ) : (
-        <JoinList token={token} handleClick={handleJoinList} />
-      )}
+      <CreateList newToken={handleCreateToken} />
+      <JoinList
+        token={token}
+        handleClick={handleJoinList}
+        handleChange={handleChange}
+      />
     </div>
   );
 };

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { getToken } from '@the-collab-lab/shopping-list-utils';
 import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
+import { getFirestore } from 'firebase/firestore';
 
 const Home = ({ token, setToken }) => {
   const [hasToken, setHasToken] = useState(token !== null);
@@ -17,12 +18,22 @@ const Home = ({ token, setToken }) => {
     setToken(newToken);
   };
 
+  const handleJoinList = () => {
+    // const token = localStorage.getItem('token')
+    console.log('this is a fun console log');
+    getFirestore.listCollections().then((collections) => {
+      for (let collection of collections) {
+        console.log(`Found collection with id: ${collection.id}`);
+      }
+    });
+  };
+
   return (
     <div>
       {!hasToken ? (
         <CreateList newToken={handleCreateToken} />
       ) : (
-        <JoinList token={token} />
+        <JoinList token={token} handleClick={handleJoinList} />
       )}
     </div>
   );

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -3,13 +3,21 @@ import { getToken } from '@the-collab-lab/shopping-list-utils';
 import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
 import { getFirestore } from 'firebase/firestore';
+import { Navigate } from 'react-router-dom';
 
-const Home = ({ token, setToken }) => {
-  const [hasToken, setHasToken] = useState(token !== null);
+const Home = ({ token, setToken, hasToken, setHasToken }) => {
+  const [joinList, setJoinList] = useState();
+
+  const handleChange = (e) => {
+    setJoinList(e.target.value);
+  };
 
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
+    if (hasToken) {
+      <Navigate to="/list" />;
+    }
   }, []);
 
   const handleCreateToken = () => {
@@ -17,24 +25,20 @@ const Home = ({ token, setToken }) => {
     localStorage.setItem('token', newToken);
     setToken(newToken);
   };
-
   const handleJoinList = () => {
-    // const token = localStorage.getItem('token')
-    console.log('this is a fun console log');
-    getFirestore.listCollections().then((collections) => {
-      for (let collection of collections) {
-        console.log(`Found collection with id: ${collection.id}`);
-      }
-    });
+    // set user input token to local storage as the token
+    // send user to List view
+    // maybe to handle error we can use a Try Catch in the useEffect on the List view
   };
 
   return (
     <div>
-      {!hasToken ? (
-        <CreateList newToken={handleCreateToken} />
-      ) : (
-        <JoinList token={token} handleClick={handleJoinList} />
-      )}
+      <CreateList newToken={handleCreateToken} />
+      <JoinList
+        token={token}
+        handleClick={handleJoinList}
+        handleChange={handleChange}
+      />
     </div>
   );
 };

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -30,11 +30,12 @@ const Home = ({ token, setToken }) => {
 
   return (
     <div>
-      {!hasToken ? (
-        <CreateList newToken={handleCreateToken} />
-      ) : (
-        <JoinList token={token} handleClick={handleJoinList} />
-      )}
+      {/* {!hasToken ? ( */}
+      <CreateList newToken={handleCreateToken} />
+      {/* ) : ( */}
+      <p> -- or -- </p>
+      <JoinList token={token} handleClick={handleJoinList} />
+      {/* )} */}
     </div>
   );
 };

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { getToken } from '@the-collab-lab/shopping-list-utils';
 import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
-import { getFirestore } from 'firebase/firestore';
-import { Navigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const Home = ({ token, setToken, hasToken, setHasToken }) => {
   const [joinList, setJoinList] = useState();
@@ -15,10 +14,14 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
-    if (hasToken) {
-      <Navigate to="/list" />;
-    }
+    useNavigateUser();
+    
   }, []);
+
+  const useNavigateUser = () => {
+    let navigate = useNavigate();
+  hasToken ? navigate(`/list`) :  navigate(`/home`)
+  }
 
   const handleCreateToken = () => {
     const newToken = getToken();
@@ -26,6 +29,8 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
     setToken(newToken);
   };
   const handleJoinList = () => {
+    localStorage.setItem('token', joinList);
+    setToken(joinList);
     // set user input token to local storage as the token
     // send user to List view
     // maybe to handle error we can use a Try Catch in the useEffect on the List view

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 const Home = ({ token, setToken, hasToken, setHasToken }) => {
   const [joinList, setJoinList] = useState();
+  const navigate = useNavigate();
 
   const handleChange = (e) => {
     setJoinList(e.target.value);
@@ -14,14 +15,11 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
-    useNavigateUser();
-    
+    const navigateToList = () => navigate(`/list`);
+    if (hasToken) {
+      navigateToList();
+    }
   }, []);
-
-  const useNavigateUser = () => {
-    let navigate = useNavigate();
-  hasToken ? navigate(`/list`) :  navigate(`/home`)
-  }
 
   const handleCreateToken = () => {
     const newToken = getToken();
@@ -31,9 +29,6 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   const handleJoinList = () => {
     localStorage.setItem('token', joinList);
     setToken(joinList);
-    // set user input token to local storage as the token
-    // send user to List view
-    // maybe to handle error we can use a Try Catch in the useEffect on the List view
   };
 
   return (

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { getToken } from '@the-collab-lab/shopping-list-utils';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../../lib/firebase';
+import { collection, getDocs, query } from 'firebase/firestore';
 import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
-import { useNavigate } from 'react-router-dom';
 
 const Home = ({ token, setToken, hasToken, setHasToken }) => {
   const [joinList, setJoinList] = useState();
+  const [formError, setFormError] = useState();
+
   const navigate = useNavigate();
 
   const handleChange = (e) => {
@@ -15,10 +19,6 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
-    const navigateToList = () => navigate(`/list`);
-    if (hasToken) {
-      navigateToList();
-    }
   }, []);
 
   const handleCreateToken = () => {
@@ -26,9 +26,23 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
     localStorage.setItem('token', newToken);
     setToken(newToken);
   };
-  const handleJoinList = () => {
-    localStorage.setItem('token', joinList);
-    setToken(joinList);
+
+  const handleJoinList = async () => {
+    //first we query the firebase database with the input token
+    const q = query(collection(db, joinList));
+    //then we take a snapshot of the results by calling getDocs() on our query
+    const querySnapshot = await getDocs(q);
+    // console.log('QUERY SNAPSHOT', querySnapshot.size)
+    // if the snapshot.size is greater than one, we can assume it's a valid list, set the token in state, and navigate the user to the list view
+    if (querySnapshot.size > 1) {
+      localStorage.setItem('token', joinList);
+      setToken(joinList);
+      navigate(`/list`);
+    }
+    // otherwise set an error in state we can pass to the join list component
+    setFormError(
+      'This token does not match an existing shopping list. Please check your input and try again.',
+    );
   };
 
   return (
@@ -38,6 +52,7 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
         token={token}
         handleClick={handleJoinList}
         handleChange={handleChange}
+        formError={formError}
       />
     </div>
   );

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -23,7 +23,7 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
     if (hasToken) {
       navigateToList();
     }
-  }, []);
+  }, [hasToken, navigate, setHasToken]);
 
   const handleCreateToken = () => {
     const newToken = getToken();

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -19,6 +19,10 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
+    const navigateToList = () => navigate(`/list`);
+    if (hasToken) {
+      navigateToList();
+    }
   }, []);
 
   const handleCreateToken = () => {

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -19,10 +19,11 @@ const Home = ({ token, setToken, hasToken, setHasToken }) => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setHasToken(token !== null);
-    const navigateToList = () => navigate(`/list`);
+
     if (hasToken) {
-      navigateToList();
+      navigate(`/list`);
     }
+    
   }, [hasToken, navigate, setHasToken]);
 
   const handleCreateToken = () => {

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
+import { Navigate } from 'react-router-dom';
 
 export default function List({ token }) {
   const [data, setData] = useState([]);

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
-import { Navigate } from 'react-router-dom';
 
 export default function List({ token }) {
   const [data, setData] = useState([]);

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -14,7 +14,7 @@ export default function List({ token }) {
     return () => {
       unsubscribe();
     };
-  }, []);
+  }, [token]);
 
   return (
     <ul>

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -6,7 +6,7 @@ export default function List({ token }) {
   const [data, setData] = useState([]);
 
   useEffect(() => {
-    const unsubscribe = onSnapshot(collection(db, 'faketoken'), (snapshot) => {
+    const unsubscribe = onSnapshot(collection(db, token), (snapshot) => {
       const snapshotDocs = [];
       snapshot.forEach((doc) => snapshotDocs.push(doc.data().property));
       setData(snapshotDocs);

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -6,7 +6,7 @@ export default function List({ token }) {
   const [data, setData] = useState([]);
 
   useEffect(() => {
-    const unsubscribe = onSnapshot(collection(db, token), (snapshot) => {
+    const unsubscribe = onSnapshot(collection(db, 'faketoken'), (snapshot) => {
       const snapshotDocs = [];
       snapshot.forEach((doc) => snapshotDocs.push(doc.data().property));
       setData(snapshotDocs);


### PR DESCRIPTION
## Description

If a user is logged in (already has a token in their `localStorage`), they are immediately shown the List page and can continue to enter items to the list. 

If a user is not logged in (does not have a token in `localStorage`), they will be shown the option to create a token or manually enter a valid token which they received from another user. 

An incorrect token will return an error as it could not be found in the Firebase database. 

## Related Issue
closes #5 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

-- When the user does not already have a token in localStorage, on the onboarding/home screen, a simple form is displayed that allows the user to enter a token

-- Entering the token and hitting submit saves the token to localStorage, effectively giving them joint control of the list

On submit, show an error if the token does not exist

If they get an error message, allow them to try again or create a new list
********
Notes:
-- As of this story, the welcome/home screen will be feature complete, as reflected in this wireframe: https://github.com/the-collab-lab/smart-shopping-list/blob/main/_resources/wireframes/welcome-screen.png
-- For accessibility reasons, use a <label> tag for the "share token" field.
-- You can assume that users will only be sharing a token if the list has actual items on it. So, let's say I create a New Shopping List, but never add any items to it, and haven't saved that particular token to Firestore, we can assume that's a list that doesn't exist.

-- If you would like, you can save the token to Firestore immediately when creating a list, and then a user would be able to share an empty list (see issue 5).

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

-- Added functionality to capture manual token input, query Firestore for that token, and return the list items (documents). 

-- Added error logic for scenario when a token is entered but is not valid

### After

https://user-images.githubusercontent.com/54855300/164915203-160bca06-9061-4ee7-98c7-3b447a8ae7d9.mov


## Testing Steps / QA Criteria

1. Start the app `npm start`
2. If you have a token in `localStorage` you should be taken directly to the List page of that token
3. If you do not have a token, you should see a screen with two user options: 
 -- a button to "Create a new list" 
-- or an input field to enter a token and a button to "Join an existing list" 
4. If you enter a valid token, you should be redirected to the List page and can add more items
5. If you enter an invalid token, you will get an error message and the chance to enter a valid token

