### PR TITLE
Record calculated estimate of how many days until an item should be purchased

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './App.css';
-import Footer from './components/Footer/Footer.jsx';
 import AddItem from './views/AddItem/AddItem.jsx';
 import List from './views/List/List.jsx';
 import Home from './views/Home/Home.jsx';

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -9,7 +9,6 @@ const INITIAL_STATE = {
   isActive: false,
   lastPurchasedAt: null,
   daysSinceLastPurchase: null,
-  previousEstimate: null,
   timesPurchased: 0,
 };
 

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -8,7 +8,6 @@ const INITIAL_STATE = {
   frequency: '7',
   isActive: false,
   lastPurchasedAt: null,
-  daysSinceLastPurchase: null,
   timesPurchased: 0,
 };
 

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -8,6 +8,9 @@ const INITIAL_STATE = {
   frequency: '7',
   isActive: false,
   lastPurchasedAt: null,
+  //daysSinceLastPurchase: null,
+  //previousEstimate: previousEstimate: Number(frequency)
+  //timesPurchased: null
 };
 
 export default function AddItem({ token }) {
@@ -49,6 +52,17 @@ export default function AddItem({ token }) {
     }
   };
 
+  // const previousEstimate = {
+  // previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases)
+  // in handle submit need to submit updated data to fb like this:
+
+  // const itemToUpdate = {
+  // previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases),
+  // item.totalPurchases: item.totalPurchases+1,
+  // purchasedDate: today(), (some function that returns today's date)
+  // }
+  // }
+
   const checkforDuplicateItems = () => {
     //get the value the user typed
     //preserve that value
@@ -75,6 +89,7 @@ export default function AddItem({ token }) {
     } catch (e) {
       console.error(e);
     }
+    //updateNumberOfPurchases();
   };
 
   const { name, frequency } = listItem;

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -83,6 +83,7 @@ export default function AddItem({ token }) {
   };
 
   const addItem = async () => {
+    listItem.frequency = parseInt(frequency, 10);
     try {
       await addDoc(collection(db, token), listItem);
     } catch (e) {

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -50,17 +50,6 @@ export default function AddItem({ token }) {
     }
   };
 
-  // const previousEstimate = {
-  // previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases)
-  // in handle submit need to submit updated data to fb like this:
-
-  // const itemToUpdate = {
-  // previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases),
-  // item.totalPurchases: item.totalPurchases+1,
-  // purchasedDate: today(), (some function that returns today's date)
-  // }
-  // }
-
   const checkforDuplicateItems = () => {
     //get the value the user typed
     //preserve that value

--- a/src/views/AddItem/AddItem.jsx
+++ b/src/views/AddItem/AddItem.jsx
@@ -8,9 +8,9 @@ const INITIAL_STATE = {
   frequency: '7',
   isActive: false,
   lastPurchasedAt: null,
-  //daysSinceLastPurchase: null,
-  //previousEstimate: previousEstimate: Number(frequency)
-  //timesPurchased: null
+  daysSinceLastPurchase: null,
+  previousEstimate: null,
+  timesPurchased: 0,
 };
 
 export default function AddItem({ token }) {

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -64,16 +64,19 @@ export default function List({ token }) {
       return item;
     });
     setData(nextData);
+    console.log(nextData);
     //then we use the updateDoc function to update Firebase
     const updatedDoc = doc(db, token, listItem.id);
     const nextActive = !isActive;
     // change nextFrequency to something else if nextActive is true or else leave it as frequency
     // frequency might a string -> turn to number
-    const nextFrequency = frequency;
+    console.log('Current frequency', frequency);
     await updateDoc(updatedDoc, {
       isActive: nextActive,
       lastPurchasedAt: nextActive ? Date.now() : lastPurchasedAt,
-      frequency: nextFrequency, // really long ternary here
+      frequency: nextActive
+        ? calculateEstimate(frequency, daysSinceLastPurchase, timesPurchased)
+        : frequency,
       daysSinceLastPurchase: nextActive
         ? Math.floor((Date.now() - lastPurchasedAt) / 86400000)
         : daysSinceLastPurchase,
@@ -87,7 +90,7 @@ export default function List({ token }) {
         {data.length ? (
           <ul>
             {data.map((listItem, index) => {
-              console.log(listItem);
+              // console.log(listItem);
               const { name, isActive } = listItem;
               return (
                 <li key={index}>

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -48,7 +48,15 @@ export default function List({ token }) {
 
   const onChange = async (listItem) => {
     //when an item is checked, we map through the data array and update the React state
-    const { isActive, id } = listItem;
+    const {
+      isActive,
+      id,
+      frequency,
+      lastPurchasedAt = Date.now(),
+      timesPurchased,
+      daysSinceLastPurchase,
+    } = listItem;
+    console.log('listItem:', listItem);
     const nextData = data.map((item) => {
       if (item.id === id) {
         item.isActive = !item.isActive;
@@ -58,9 +66,18 @@ export default function List({ token }) {
     setData(nextData);
     //then we use the updateDoc function to update Firebase
     const updatedDoc = doc(db, token, listItem.id);
+    const nextActive = !isActive;
+    // change nextFrequency to something else if nextActive is true or else leave it as frequency
+    // frequency might a string -> turn to number
+    const nextFrequency = frequency;
     await updateDoc(updatedDoc, {
-      isActive: !isActive,
-      lastPurchasedAt: Date.now(),
+      isActive: nextActive,
+      lastPurchasedAt: nextActive ? Date.now() : lastPurchasedAt,
+      frequency: nextFrequency, // really long ternary here
+      daysSinceLastPurchase: nextActive
+        ? Math.floor((Date.now() - lastPurchasedAt) / 86400000)
+        : daysSinceLastPurchase,
+      timesPurchased: nextActive ? timesPurchased + 1 : timesPurchased,
     });
   };
 

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -29,6 +29,9 @@ export default function List({ token }) {
   // on each re-render, we loop through the react data array to check the current time against the last purchased at time
   useEffect(() => {
     data.forEach((item) => {
+      if (item.lastPurchasedAt === null) {
+        return;
+      }
       const now = Date.now();
       const delta = now - item.lastPurchasedAt;
       // we then feed the delta and the item into our unCheck function and if the item has a delta greater than 86400000 we run update the isActive property in firebase

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -3,6 +3,7 @@ import { collection, doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import { Link } from 'react-router-dom';
 import { SiProbot } from 'react-icons/si';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import '../../App.css';
 import './List.css';
 import Footer from '../../components/Footer/Footer';
@@ -79,6 +80,7 @@ export default function List({ token }) {
                     checked={isActive}
                     type="checkbox"
                     id={name}
+                    name={listItem.id}
                   />{' '}
                   <label htmlFor={name}>{name}</label>
                 </li>
@@ -102,3 +104,17 @@ export default function List({ token }) {
     </section>
   );
 }
+
+// const itemToUpdate = {
+//   previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases),
+//   item.totalPurchases: item.totalPurchases+1,
+//   purchasedDate: today(), (some function that returns today's date)
+//   }
+
+// const dateOfLastTransaction =
+//       itemToUpdate.totalPurchases > 0
+//         ? itemToUpdate.lastPurchasedAt
+//         : itemToUpdate.createdAt;
+
+// const daysSinceLastTransaction =
+//       (Date.now() - dateOfLastTransaction) / Math.pow(8.64, 7);

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -51,15 +51,8 @@ export default function List({ token }) {
 
   const onChange = async (listItem) => {
     //when an item is checked, we map through the data array and update the React state
-    const {
-      isActive,
-      id,
-      frequency,
-      lastPurchasedAt = Date.now(),
-      timesPurchased,
-      daysSinceLastPurchase,
-    } = listItem;
-    console.log('listItem:', listItem);
+    const { isActive, id, frequency, lastPurchasedAt, timesPurchased } =
+      listItem;
     const nextData = data.map((item) => {
       if (item.id === id) {
         item.isActive = !item.isActive;
@@ -67,30 +60,27 @@ export default function List({ token }) {
       return item;
     });
     setData(nextData);
-    console.log(nextData);
     //then we use the updateDoc function to update Firebase
     const updatedDoc = doc(db, token, listItem.id);
     const now = Date.now();
     const nextActive = !isActive;
-    // `calculateEstimate` relies on some information that we have to
-    // compute before we can run it.
-    const nextLastPurchasedAt = nextActive ? Date.now() : lastPurchasedAt;
-    const nextDaysSinceLastPurchase = nextActive
-      ? Math.floor((now - lastPurchasedAt) / 86400000) || 1
-      : daysSinceLastPurchase;
-    const nextTimesPurchased = nextActive ? timesPurchased + 1 : timesPurchased;
-
-    const nextFrequency = nextActive
-      ? calculateEstimate(frequency, nextDaysSinceLastPurchase, timesPurchased)
-      : frequency;
-
-    await updateDoc(updatedDoc, {
+    const update = {
       isActive: nextActive,
-      lastPurchasedAt: nextLastPurchasedAt,
-      frequency: nextFrequency,
-      daysSinceLastPurchase: nextDaysSinceLastPurchase,
-      timesPurchased: nextTimesPurchased,
-    });
+    };
+    if (nextActive) {
+      const daysSinceLastPurchase = lastPurchasedAt
+        ? Math.floor((now - lastPurchasedAt) / 86400000)
+        : frequency;
+      update.timesPurchased = timesPurchased + 1;
+      update.lastPurchasedAt = now;
+      update.frequency = calculateEstimate(
+        frequency,
+        daysSinceLastPurchase,
+        update.timesPurchased,
+      );
+    }
+
+    await updateDoc(updatedDoc, update);
   };
 
   return (

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -123,17 +123,3 @@ export default function List({ token }) {
     </section>
   );
 }
-
-// const itemToUpdate = {
-//   previousEstimate: calculateEstimate(item.previousEstimate, item.daysSinceLastPurchase, item.totalPurchases),
-//   item.totalPurchases: item.totalPurchases+1,
-//   purchasedDate: today(), (some function that returns today's date)
-//   }
-
-// const dateOfLastTransaction =
-//       itemToUpdate.totalPurchases > 0
-//         ? itemToUpdate.lastPurchasedAt
-//         : itemToUpdate.createdAt;
-
-// const daysSinceLastTransaction =
-//       (Date.now() - dateOfLastTransaction) / Math.pow(8.64, 7);


### PR DESCRIPTION
## Description

New functionality:
- added `timesPurchased` to INITIAL_STATE
- used `calculateEstimate` function as provided in `@the-collab-lab/shopping-list-utils` to derive a new `frequency` each time an item was purchased (checkbox was made active)

Bug fixes:
- converted `frequency` to an integer before sending to Firebase (AddItem.jsx line 74)
- added conditional (List.jsx line 32) that allows the `useEffect `function to only `unCheckItem(item, delta)` if the item had already been purchased at least once. 
- added `[token]` to dependency array as it was calling Firebase for every keystroke; we hit our limit! 

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

## Related Issue

Closes #10 

## Acceptance Criteria

- When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database
-- The function calculateEstimate from @the-collab-lab/shopping-list-utils should be used to calculate the next estimated purchase interval. This should already be installed in your project from issue https://github.com/the-collab-lab/tcl-40-smart-shopping-list/issues/3.

-- calculateEstimate accepts three arguments. They are, in order:

-- previousEstimate (a number): The last estimated purchase interval
-- daysSinceLastTransaction (a number): The number of days since the item was added to the list or last purchased
-- totalPurchases (a number): The total number of purchases made for the item
Given this information, calculateEstimate returns a whole number indicating the number of days until the user is likely to buy this item again.


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

In Firebase: 

<img width="733" alt="Screen Shot 2022-05-06 at 5 31 28 PM" src="https://user-images.githubusercontent.com/52385888/167219097-4c87ac6d-ed7d-4f6b-a264-731354dad466.png">


### After
<img width="837" alt="Screen Shot 2022-05-06 at 7 01 51 PM" src="https://user-images.githubusercontent.com/52385888/167226192-38cafd97-0d66-4a28-86e0-51761225e92d.png">



## Testing Steps / QA Criteria

(This is easiest to test with both the UI and Firebase open side by side in your browser.)

In the UI:
-checkout branch `dh-sp-next-purchase`
-delete your token from `localStorage`
-create a new list
-add a few items and choose different frequency values

In Firebase:
- navigate to your list by finding your `token`
- look for the first item in your list so you can see all the fields/properties
<img width="773" alt="Screen Shot 2022-05-06 at 6 39 25 PM" src="https://user-images.githubusercontent.com/52385888/167224673-6e3e4384-7542-4d14-8525-7fa86271e7fc.png">

In the UI:
- check an item and note how Firebase fields change -->
 As you toggle the checkbox to selected/active, you should see:
- `timesPurchased` increasing every time you make the checkbox active 
- the `frequency` will start at the level you selected (7 = soon, 14=kind of soon, 30=not soon)
- each time you make the item active, the frequency will reduce, per the `calculateEstimate` function; the app is learning that you are purchasing the item more frequently. 
- `lastPurchasedAt` will also change to reflect the current time

When the check box is not selected/inactive, you should not see a change in the field data apart from `isActive` (it will change to `false`)

https://user-images.githubusercontent.com/52385888/167225727-d82711fb-24ab-4314-a321-50abe6c9f527.mov


