### PR TITLE
Sort list items by need

### DIFF
--- a/src/views/List/List.css
+++ b/src/views/List/List.css
@@ -23,3 +23,19 @@
 .message {
   margin-top: 2rem;
 }
+
+.soon {
+  background-color: yellow;
+}
+
+.kind-of-soon {
+  background-color: blue;
+}
+
+.not-soon {
+  background-color: red;
+}
+
+.inactive {
+  background-color: gray;
+}

--- a/src/views/List/List.css
+++ b/src/views/List/List.css
@@ -25,17 +25,21 @@
 }
 
 .soon {
-  background-color: yellow;
+  background-color: gold;
 }
 
 .kind-of-soon {
-  background-color: blue;
+  background-color: lightblue;
 }
 
 .not-soon {
-  background-color: red;
+  background-color: lightsalmon;
 }
 
 .inactive {
-  background-color: gray;
+  background-color: lightgray;
+}
+
+.badge {
+  background-color: white;
 }

--- a/src/views/List/List.css
+++ b/src/views/List/List.css
@@ -33,7 +33,7 @@
 }
 
 .not-soon {
-  background-color: lightsalmon;
+  background-color: lightpink;
 }
 
 .inactive {

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -163,97 +163,39 @@ export default function List({ token }) {
                 timesPurchased,
                 lastPurchasedAt,
               } = listItem;
+              let buyIndicator = '';
+              let badge = '';
               if (
-                frequency < 7 &&
-                (Date.now() - lastPurchasedAt) / 86400000 < frequency * 2
-              ) {
-                return (
-                  <li key={index} className="soon">
-                    {' '}
-                    <input
-                      aria-invalid={toggleErr}
-                      aria-describedby="search-err"
-                      aria-errormessage="search-err"
-                      onChange={() => onChange(listItem)}
-                      checked={isActive}
-                      type="checkbox"
-                      id={name}
-                      name={listItem.id}
-                    />{' '}
-                    <label htmlFor={name}>
-                      {name}
-                      {frequency}
-                    </label>
-                  </li>
-                );
-              } else if (
-                frequency >= 7 &&
-                frequency <= 30 &&
-                (Date.now() - lastPurchasedAt) / 86400000 < frequency * 2
-              ) {
-                return (
-                  <li key={index} className="kind-of-soon">
-                    {' '}
-                    <input
-                      aria-invalid={toggleErr}
-                      aria-describedby="search-err"
-                      aria-errormessage="search-err"
-                      onChange={() => onChange(listItem)}
-                      checked={isActive}
-                      type="checkbox"
-                      id={name}
-                      name={listItem.id}
-                    />{' '}
-                    <label htmlFor={name}>
-                      {name}
-                      {frequency}
-                    </label>
-                  </li>
-                );
-              } else if (
                 timesPurchased === 1 ||
                 (Date.now() - lastPurchasedAt) / 86400000 >= frequency * 2
               ) {
-                return (
-                  <li key={index} className="inactive">
-                    {' '}
-                    <input
-                      aria-invalid={toggleErr}
-                      aria-describedby="search-err"
-                      aria-errormessage="search-err"
-                      onChange={() => onChange(listItem)}
-                      checked={isActive}
-                      type="checkbox"
-                      id={name}
-                      name={listItem.id}
-                    />{' '}
-                    <label htmlFor={name}>
-                      {name}
-                      {frequency}
-                    </label>
-                  </li>
-                );
-              } else {
-                return (
-                  <li key={index} className="not-soon">
-                    {' '}
-                    <input
-                      aria-invalid={toggleErr}
-                      aria-describedby="search-err"
-                      aria-errormessage="search-err"
-                      onChange={() => onChange(listItem)}
-                      checked={isActive}
-                      type="checkbox"
-                      id={name}
-                      name={listItem.id}
-                    />{' '}
-                    <label htmlFor={name}>
-                      {name}
-                      {frequency}
-                    </label>
-                  </li>
-                );
+                buyIndicator = 'inactive';
+              } else if (frequency < 7) {
+                buyIndicator = 'soon';
+              } else if (frequency >= 7 && frequency <= 30) {
+                buyIndicator = 'kind-of-soon';
+              } else if (frequency > 30) {
+                buyIndicator = 'not-soon';
               }
+              badge = buyIndicator.replace('-', ' ');
+              return (
+                <li key={index} className={buyIndicator}>
+                  {' '}
+                  <input
+                    aria-invalid={toggleErr}
+                    aria-describedby="search-err"
+                    aria-errormessage="search-err"
+                    onChange={() => onChange(listItem)}
+                    checked={isActive}
+                    type="checkbox"
+                    id={name}
+                    name={listItem.id}
+                  />{' '}
+                  <label htmlFor={name}>
+                    {name} ({badge})
+                  </label>
+                </li>
+              );
             })}
           </ul>
         ) : (

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -167,7 +167,8 @@ export default function List({ token }) {
               let badge = '';
               if (
                 timesPurchased === 1 ||
-                (Date.now() - lastPurchasedAt) / 86400000 >= frequency * 2
+                ((Date.now() - lastPurchasedAt) / 86400000 >= frequency * 2 &&
+                  lastPurchasedAt !== null)
               ) {
                 buyIndicator = 'inactive';
               } else if (frequency < 7) {

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -192,7 +192,10 @@ export default function List({ token }) {
                     name={listItem.id}
                   />{' '}
                   <label htmlFor={name}>
-                    {name} ({badge})
+                    {name}{' '}
+                    <small className="badge">
+                      <strong>{badge}</strong>
+                    </small>
                   </label>
                 </li>
               );

--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -25,9 +25,15 @@ export default function List({ token }) {
         data.id = doc.id;
         snapshotDocs.push(data);
       });
-      setData(snapshotDocs);
+      const sortedName = snapshotDocs.sort((a, b) => {
+        return a.name.localeCompare(b.name);
+      });
+      const sortedFrequency = sortedName.sort((a, b) => {
+        return a.frequency - b.frequency;
+      });
+      setData(sortedFrequency);
       //duplicate data from firebase to be manipulated
-      setCopyOfData(snapshotDocs);
+      setCopyOfData(sortedFrequency);
     });
     return () => {
       unsubscribe();
@@ -150,23 +156,104 @@ export default function List({ token }) {
               </p>
             ) : null}
             {copyOfData.map((listItem, index) => {
-              const { name, isActive } = listItem;
-              return (
-                <li key={index}>
-                  {' '}
-                  <input
-                    aria-invalid={toggleErr}
-                    aria-describedby="search-err"
-                    aria-errormessage="search-err"
-                    onChange={() => onChange(listItem)}
-                    checked={isActive}
-                    type="checkbox"
-                    id={name}
-                    name={listItem.id}
-                  />{' '}
-                  <label htmlFor={name}>{name}</label>
-                </li>
-              );
+              const {
+                name,
+                isActive,
+                frequency,
+                timesPurchased,
+                lastPurchasedAt,
+              } = listItem;
+              if (
+                frequency < 7 &&
+                (Date.now() - lastPurchasedAt) / 86400000 < frequency * 2
+              ) {
+                return (
+                  <li key={index} className="soon">
+                    {' '}
+                    <input
+                      aria-invalid={toggleErr}
+                      aria-describedby="search-err"
+                      aria-errormessage="search-err"
+                      onChange={() => onChange(listItem)}
+                      checked={isActive}
+                      type="checkbox"
+                      id={name}
+                      name={listItem.id}
+                    />{' '}
+                    <label htmlFor={name}>
+                      {name}
+                      {frequency}
+                    </label>
+                  </li>
+                );
+              } else if (
+                frequency >= 7 &&
+                frequency <= 30 &&
+                (Date.now() - lastPurchasedAt) / 86400000 < frequency * 2
+              ) {
+                return (
+                  <li key={index} className="kind-of-soon">
+                    {' '}
+                    <input
+                      aria-invalid={toggleErr}
+                      aria-describedby="search-err"
+                      aria-errormessage="search-err"
+                      onChange={() => onChange(listItem)}
+                      checked={isActive}
+                      type="checkbox"
+                      id={name}
+                      name={listItem.id}
+                    />{' '}
+                    <label htmlFor={name}>
+                      {name}
+                      {frequency}
+                    </label>
+                  </li>
+                );
+              } else if (
+                timesPurchased === 1 ||
+                (Date.now() - lastPurchasedAt) / 86400000 >= frequency * 2
+              ) {
+                return (
+                  <li key={index} className="inactive">
+                    {' '}
+                    <input
+                      aria-invalid={toggleErr}
+                      aria-describedby="search-err"
+                      aria-errormessage="search-err"
+                      onChange={() => onChange(listItem)}
+                      checked={isActive}
+                      type="checkbox"
+                      id={name}
+                      name={listItem.id}
+                    />{' '}
+                    <label htmlFor={name}>
+                      {name}
+                      {frequency}
+                    </label>
+                  </li>
+                );
+              } else {
+                return (
+                  <li key={index} className="not-soon">
+                    {' '}
+                    <input
+                      aria-invalid={toggleErr}
+                      aria-describedby="search-err"
+                      aria-errormessage="search-err"
+                      onChange={() => onChange(listItem)}
+                      checked={isActive}
+                      type="checkbox"
+                      id={name}
+                      name={listItem.id}
+                    />{' '}
+                    <label htmlFor={name}>
+                      {name}
+                      {frequency}
+                    </label>
+                  </li>
+                );
+              }
             })}
           </ul>
         ) : (


### PR DESCRIPTION
## Description

This PR sorts the shopping list by frequency in ascending order.  For any items that all have the same frequency, they are further sorted alphabetically within that group.  The frequency ranges are as follows:

- Need to buy soon (fewer than 7 days)
- Need to buy kind of soon (between 7 & 30 days)
- Need to buy not soon (more than 30 days)
- Inactive (when there’s only 1 purchase in the database or the purchase is really out of date [the time that has elapsed since the last purchase is 2x what was estimated])

The frequency ranges listed above have been assigned a corresponding class that changes the background so that they are visually distinct.  A badge has also been added to each list item indicating which frequency range it is associated with.  A screen reader will announce the name of the list item as well as the text from the accompanying badge.

## Related Issue

closes #12 

## Acceptance Criteria

- Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- Items should be sorted by the estimated number of days until the next purchase
- Items with the same number of estimated days until next purchase should be sorted alphabetically
- Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![Screenshot (127)](https://user-images.githubusercontent.com/83678228/168162818-3dd26cd7-f5a9-45ee-957a-c71eedd997d3.png)


### After
![Screenshot (125)](https://user-images.githubusercontent.com/83678228/167958139-972dd1cd-30ff-489b-8c80-3332e980b017.png)

### Video using NVDA screen reader announcing list items & badge

https://user-images.githubusercontent.com/83678228/167965956-9400a54e-0638-4cde-9755-15821c754a9d.mp4


## Testing Steps / QA Criteria

Checkout branch `dh-nj-sort-by-need`

1. Clear your local storage and create a new list
2. Add a few items (at least 4, so that at least 2 items will have the same frequency) to your list and select at least one of each frequency (soon, kind of soon, not soon)
3. All of the list items should be light blue and with a white label that says "kind of soon" (the frequency ranges in our issue are greater than what we initially set when we first started building this app) which is why the labels don't initially correspond to the radio buttons that were selected
4. Go to Firebase, and check the frequency of each item to make sure they are sorted by frequency.  The item with the lowest frequency should be displayed first in the list view, and the item with the highest frequency should be displayed last in the list view. 
5. Go back to the list and these two items should be sorted alphabetically (only focus on these two items)
6. Next, find the item with a frequency of 7 and select that checkbox, the background color should change from light blue to gray and the badge should change to "inactive". This is because the times purchased is 1, which makes an item fall into the "inactive" category.
7. Select that same item a second time, the background color should change from light gray to yellow and the badge should now say "soon"
8. In firebase, find the item with the highest frequency, go back to the list and select the checkbox for that item, then go back to firebase and edit the frequency of that item to a number equal to 31 or higher.  If needed, also edit the timesPurchased property to a number higher than 1.  The background of that list item should now be light pink with a badge that says "not soon".
9. To test for an inactive item in terms of the date, select the checkbox if it isn't already selected, find the item in firebase and edit the timesPurchased property to any number greater than 1
10. Go to the [Big Number Calculator Site](https://www.calculator.net/big-number-calculator.html)  (Right click or copy the link and open in a new tab)
 - In the X = box paste 86400000 (1 day in milliseconds)
 - multiply the associated frequency by 2
 - paste only the result of the above step in the Y = box
 - Click the X * Y button
 - Copy the result and paste it into the Y =  box (removing the commas and replacing the current value)
 - In firebase, copy the lastPurchasedAt property for the same item and paste it into the X = box
 - Click the X - Y button (this will deduct 2 x the frequency in days from the lastPurchasedAt date )
 - Copy the result and paste this value in lastPurchasedAt property (remove the commas)
 - Click update
 -  We have now changed the date back in time to reflect not buying an item for (2 x the frequency) worth of days
 - Go back to the list view, this items background color should now be light gray, with a badge of "inactive"

Per our issue: 
E.g., if the last estimate was 14 days and 28 days have elapsed, the item is considered inactive.
 

