### PR TITLE
Removed duplicate list item name; moved Delete button to end of item row

### DIFF
--- a/src/views/List/List.jsx
+++ b/src/views/List/List.jsx
@@ -212,18 +212,17 @@ export default function List({ token }) {
                     name={listItem.id}
                   />{' '}
                   <label htmlFor={name}>{name}</label>
+                  <label htmlFor={name}>
+                    <small className="badge">
+                      <strong>{badge}</strong>
+                    </small>
+                  </label>
                   <button
                     className="delete-button"
                     onClick={() => deleteItem(listItem)}
                   >
                     Delete
                   </button>
-                  <label htmlFor={name}>
-                    {name}{' '}
-                    <small className="badge">
-                      <strong>{badge}</strong>
-                    </small>
-                  </label>
                 </li>
               );
             })}


### PR DESCRIPTION

## Description

When starting to work on the next issue, I noticed that on the current version of `main` branch, each list item appears 2x. Also, the `delete` button came before the `badge`, whereas it was intended to appear at the end of the row. 

## Related Issue

Resulted from merging #11 and #12 as both PRs added code to the list item

## Acceptance Criteria

- should only see the list item once in the `<li>`
- Delete button should appear at the end of each `<li>`. 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="470" alt="Screen Shot 2022-05-19 at 2 27 36 PM" src="https://user-images.githubusercontent.com/52385888/169373681-a0272584-cc8f-4956-9f07-8003828ef5d3.png">

### After

<img width="392" alt="Screen Shot 2022-05-19 at 2 27 12 PM" src="https://user-images.githubusercontent.com/52385888/169373614-3dffa39d-58d5-4057-b05f-3fc0088493b8.png">

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

