### PR TITLE
Adds color and font variables for styling use

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800;900&display=swap');
+
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,400;0,600;0,700;1,200&display=swap');
+
+:root {
+  --darkpurple: #120310;
+  --purple: #22061f;
+  --pink: #63264a;
+  --teal: #548687;
+  --orange: #f28f3b;
+  --white: #f9f8f8;
+  --fontHeader: 'Playfair Display', serif;
+  --fontBody: 'Source Sans Pro', sans-serif;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
## Description

This PR adds variables to our index.css for our agreed upon color palette, as well as a header and body font for use while styling the app. 

## Related Issue

closes #31 

## Acceptance Criteria

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |


## Testing Steps / QA Criteria

- pull down branch `ks-css-vars`
- in the index.css file, you should see a root styling declaration that has 8 variables (2 fonts, and 6 colors)

