### PR TITLE
Sp home style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,6 +40,7 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-top: 2rem;
-  padding-bottom: 2rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  margin: 1rem;
 }

--- a/src/components/Home/CreateList.jsx
+++ b/src/components/Home/CreateList.jsx
@@ -9,6 +9,8 @@ const CreateList = (props) => {
       <button className="createButton" onClick={props.newToken}>
         Create a new token
       </button>
+      <p>Your token will become a list when you add your first item.</p>
+      <p>_______________________________</p>
     </div>
   );
 };

--- a/src/components/Home/CreateList.jsx
+++ b/src/components/Home/CreateList.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import '../../App.css';
+import './Home.css';
 
 const CreateList = (props) => {
   return (
     <div>
       <h3>Welcome to your Smart Shopping list!</h3>
-      <button onClick={props.newToken}>Create a new token</button>
+      <button className="createButton" onClick={props.newToken}>
+        Create a new token
+      </button>
     </div>
   );
 };

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -1,0 +1,39 @@
+.div {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: flex-start;
+  height: calc(100vh - 75px);
+  gap: 1rem;
+  max-width: 500px;
+  width: 90vw;
+  padding: 0.25rem;
+  margin: 0 auto;
+}
+
+h3 {
+  margin: 1rem;
+}
+
+p {
+  margin: 1rem;
+}
+
+.createButton,
+.joinButton {
+  color: var(--white);
+  border: none;
+  background-color: var(--pink);
+  font-family: var(--fontBody);
+  font-weight: 900;
+  padding: 1rem;
+}
+
+.share-token-div {
+  padding: 0.5rem;
+  margin: 0.5rem;
+}
+
+.share-token-input {
+  padding-right: 0.2rem;
+}

--- a/src/components/Home/JoinList.jsx
+++ b/src/components/Home/JoinList.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import '../../App.css';
+import './Home.css';
 
 const JoinList = ({
   token,
@@ -12,12 +14,18 @@ const JoinList = ({
       {formError ? (
         <p>{formError}</p>
       ) : (
-        <p> Join an existing shopping list by entering a three word token </p>
+        <p>
+          {' '}
+          Join an existing shopping list by entering a valid three word token{' '}
+        </p>
       )}
-      <div>
-        <label htmlFor="share-token">Share Token:</label>
+      <div className="share-token-div">
+        <label className="share-token-input" htmlFor="share-token">
+          Token:
+        </label>
         <input
           id="share-token"
+          // className="share-token-input"
           type="search"
           list="token-list"
           placeholder="three word token"
@@ -37,7 +45,9 @@ const JoinList = ({
             : null}
         </datalist>
       </div>
-      <button onClick={handleClick}>Join an existing list</button>
+      <button className="joinButton" onClick={handleClick}>
+        Join an existing list
+      </button>
     </div>
   );
 };

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -7,6 +7,7 @@ import CreateList from '../../components/Home/CreateList';
 import JoinList from '../../components/Home/JoinList';
 import Header from '../../components/Header/Header.jsx';
 import Footer from '../../components/Footer/Footer.jsx';
+import '../../App.css';
 
 const Home = ({
   activeToken,
@@ -54,18 +55,20 @@ const Home = ({
   };
 
   return (
-    <div>
-      <Header />
-      <CreateList newToken={handleCreateToken} />
-      <JoinList
-        token={activeToken}
-        handleClick={handleJoinList}
-        handleChange={handleChange}
-        formError={formError}
-        tokenList={tokenList}
-      />
-      <div>{activeToken ? <Footer /> : null}</div>
-    </div>
+    <section>
+      <div className="div">
+        <Header />
+        <CreateList newToken={handleCreateToken} />
+        <JoinList
+          token={activeToken}
+          handleClick={handleJoinList}
+          handleChange={handleChange}
+          formError={formError}
+          tokenList={tokenList}
+        />
+        <div>{activeToken ? <Footer /> : null}</div>
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

This PR updates the styling of the Home page to be consistent with the chosen color palette. 

## Related Issue
Closes #49 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- User is informed that their token becomes a list when the add their first item. 
- Styling is more in-line with the `List` page

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
<img width="391" alt="Screen Shot 2022-05-28 at 1 04 54 PM" src="https://user-images.githubusercontent.com/52385888/170835473-5fc87f2f-7700-406f-874f-04f82fb704cc.png">

### After
<img width="377" alt="Screen Shot 2022-05-28 at 1 04 22 PM" src="https://user-images.githubusercontent.com/52385888/170835454-b98d9a83-c5b6-4c8a-a4e7-42cec0198d44.png">


## Testing Steps / QA Criteria

- pull down branch `sp-home-style`
- observe changes to UI as shown above

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

**TODO**: Footer still needs to be consistently fixed to bottom of each page
